### PR TITLE
Fix #50: support non-aws non-x509 mqtt connection points.

### DIFF
--- a/MQTT-PROTOCOL.md
+++ b/MQTT-PROTOCOL.md
@@ -2,7 +2,7 @@
 
 # SnappySense MQTT protocol
 
-If configured with a network the device will connect to AWS IoT via MQTT every so often to upload
+If configured with a network the device will connect to an MQTT message broker every so often to upload
 sensor data and receive commands.  The communication window remains open for a little while; data
 and commands generated while the window is closed will be queued (modulo device limits) until the
 window is open.  The device fleet is small and messages are fairly infrequent, so messages should be
@@ -50,9 +50,10 @@ clashes.  See the FACTOR table of DATA-MODEL.md for the `<factor-name>` values.
 
 ## Control message
 
-AWS IoT can send a control message to the device via the topics `snappy/control/<device-id>`,
-`snappy/control-class/<device-class>` and `snappy/control-all`, to which the device can subscribe.  The
-message has a JSON payload with at least these fields:
+The message broker (or really, code behind it that it routes messages to) can send a control message
+to the device via the topics `snappy/control/<device-id>`, `snappy/control-class/<device-class>` and
+`snappy/control-all`, to which the device can subscribe.  The message has a JSON payload with at
+least these fields:
 
 ```
   enable: <integer, 0 or 1, whether to enable or disable device, OPTIONAL>,
@@ -64,6 +65,6 @@ controls how often the measurements are taken.
 
 ## Command message
 
-AWS IoT can send a command message to the device via the topic `snappy/command/<device-id>` (and
-unlike control message, not to the class or to all devices) with a JSON payload.  There are not currently
-anny command messages.
+The message broker (or really, code behind it that it routes messages to) can send a command message
+to the device via the topic `snappy/command/<device-id>` (and unlike control message, not to the
+class or to all devices) with a JSON payload.  There are not currently anny command messages.

--- a/aws/IOT-THINGS.md
+++ b/aws/IOT-THINGS.md
@@ -121,7 +121,7 @@ format of this file is described in detail in [../CONFIG.md](../CONFIG.md).
 
 _This file will contain secrets and must not be checked into github._
 
-Add the necessary information to the new file as described in the comments.  The `aws-iot-id` shall
+Add the necessary information to the new file as described in the comments.  The `mqtt-id` shall
 be the name of the device, `snp_x_y_no_z`, as chosen above.  The device certificate, private key,
 and root cert must be the ones downloaded.
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -35,8 +35,8 @@ required work is described in several documents:
 Current technical documents about data formats and protocols:
 
 * [DATA-MODEL.md](DATA-MODEL.md) describes the data model of the back-end databases.
-* [MQTT-PROTOCOL.md](MQTT-PROTOCOL.md) describes the details of the communication protocols used to 
-  communicate between the devices and AWS IoT.
+* [../MQTT-PROTOCOL.md](../MQTT-PROTOCOL.md) describes the details of the communication protocols used to 
+  communicate between the devices and AWS IoT (or any other MQTT broker).
 
 Code is mostly in subdirectories:
 

--- a/firmware-arduino/src/config.h
+++ b/firmware-arduino/src/config.h
@@ -130,8 +130,28 @@ unsigned long time_server_retry_s();
 const char* mqtt_endpoint_host();
 int mqtt_endpoint_port();
 
+enum class MqttAuth {
+  UNKNOWN = 0,
+  CERT_BASED = 1,
+  USER_AND_PASS = 2
+};
+MqttAuth mqtt_auth_type();
+
+// Use a Tls connection or not.  This can be configured as a setting, but the setting
+// must be true for mqtt_auth_type() == CERT_BASED.  If a root cert is not defined then
+// this must return false.  See the config consistency checks for more.
+bool mqtt_tls();
+
 // Keys and certificates
+// Root cert for TLS connection
 const char* mqtt_root_ca_cert();
+
+// For user+pass-based connection (eg RabbitMQ testing setup): username and password
+// These could be the same as device ID but that seems unnecessarily constraining
+const char* mqtt_username();
+const char* mqtt_password();
+
+// For cert-based connection (eg AWS setup): device cert and device private key
 const char* mqtt_device_cert();
 const char* mqtt_device_private_key();
 #endif

--- a/firmware-arduino/src/configuration_template.txt
+++ b/firmware-arduino/src/configuration_template.txt
@@ -1,4 +1,4 @@
-version 1.1.0
+version 2.0.0
 
 # See CONFIG.md for full documentation about what it means and how it's used.
 
@@ -18,40 +18,59 @@ set password1 ...FIXME...
 #set ssid3 ...FIXME...
 #set password3 ...FIXME...
 
-# Sensor location ID - this is just a string, but it should be a string that is
-# defined in the backend systems' database.
-set location ...FIXME...
+# Access point name (used for end-user config) is per-device since multiple devices can be active in
+# the same area at the same time.  Something derived from the mqtt-id is sensible, eg, if
+# mqtt-id is snp_1_1_no_48 (v1.1 device s/n 48) then using snp_1_1_no_48_cfg here is OK, note
+# the name is at most 32 characters, and it's helpful to keep it <= 20, for display purposes.  Using
+# "snp_" and "_cfg" makes it easy to recognize the network but is not required.
 
-# Access point name (used for end-user config) is per-device since multiple devices
-# can be active in the same area at the same time.  Something derived from the aws-iot-id
-# is sensible, eg, if aws-iot-id is snp_1_1_no_48 (v1.1 device s/n 48) then using
-# snp_1_1_no_48_config here is OK, note the name is at most 32 characters, and it's
-# helpful to keep it <= 20, for display purposes.  Using "snp_" and "_config" makes it
-# easy to recognize the network but is not required.
 set web-config-access-point ...FIXME...
 
-# All of the following except the class comes from AWS IoT.
-# The class is "snappysense" for the SnappySense devices; TBD for other
-# versions or other devices.
+# MQTT overall configuration.
+#
+# The ID is the AWS IoT Thing ID, if you're using AWS.
+#
+# The class is "snappysense" for the SnappySense devices; TBD for other versions or other devices.
 
-set aws-iot-endpoint-host ...FIXME...
-set aws-iot-id ...FIXME...
-set aws-iot-class "snappysense"
+set mqtt-id ...FIXME...
+set mqtt-class "snappysense"
+
+# A setup meaningful for local testing and some non-AWS brokers.  lth uses this with rabbitmq
+# running on his own laptop.  The host name is usually `whatever.local`, and the username and
+# password is something the broker can do, for rabbitmq this might be `guest` and `guest`.  Note for
+# mqtt-use-tls=1 there must be a root cert and the port will be 8883.
+
+set mqtt-auth pass
+set mqtt-endpoint-host ...FIXME...
+set mqtt-use-tls 0
+set mqtt-endpoint-port 1883
+set mqtt-username ...FIXME...
+set mqtt-password ...FIXME...
+
+# AWS IoT MQTT.  For mqtt-use-tls=1 there must be an mqtt-root-cert, and for
+# mqtt-auth=x509 there must be device cert and private key.  The host will
+# be somethingsomething.region.amazonaws.com
+
+#set mqtt-use-tls 1
+#set mqtt-auth x509
+#set mqtt-endpoint-host ...FIXME...
+#set mqtt-endpoint-port 8883
 
 # Amazon Root CA 1 (AmazonRootCA1.pem)
-cert aws-iot-root-ca
+cert mqtt-root-cert
 -----BEGIN CERTIFICATE-----
 ...FIXME...
 -----END CERTIFICATE-----
 
+
 # Device Certificate (XXXXXXXXXX-certificate.pem.crt)
-cert aws-iot-device-cert
+cert mqtt-device-cert
 -----BEGIN CERTIFICATE-----
 ...FIXME...
 -----END CERTIFICATE-----
 
 # Device Private Key (XXXXXXXXXX-private.pem.key)
-cert aws-iot-private-key
+cert mqtt-private-key
 -----BEGIN RSA PRIVATE KEY-----
 ...FIXME...
 -----END RSA PRIVATE KEY-----

--- a/firmware-arduino/src/development_config_template.txt
+++ b/firmware-arduino/src/development_config_template.txt
@@ -10,37 +10,41 @@
 static const char WIFI_SSID[] = "...";          // FIXME
 static const char WIFI_PASSWORD[] = "......";   // FIXME
 
-// -------------------------------------------------------------------------------
-//
-// Sensor location identification
-
-static const char LOCATION_NAME[] = "...";      // FIXME
-
 #ifdef SNAPPY_MQTT
 // -------------------------------------------------------------------------------
 //
-// AWS MQTT credentials
+// Basic MQTT credentials
 
-static const char AWS_IOT_ENDPOINT[] = "...";     // FIXME
-static const int AWS_MQTT_PORT=8883;              // Useful default
-static const char AWS_CLIENT_IDENTIFIER[]="...";  // FIXME
+static const char MQTT_ENDPOINT[] = "...";     // FIXME
+static const int MQTT_PORT=8883;              // Useful default
+static const char MQTT_ID[]="...";  // FIXME
+static const int MQTT_TLS = ...FIXME...; // 0 or 1
+static const char MQTT_AUTH[] = ...FIXME...; // "x509" or "pass"
+static const char MQTT_USER[] = ...FIXME...; // username if "pass", otherwise empty
+static const char MQTT_PASS[] = ...FIXME...; // password if "pass", otherwise empty
 
-// Amazon Root CA 1 (AmazonRootCA1.pem)
-static const char AWS_CERT_CA[] = R"ROOTCA(
+// This is for MQTT_TLS==1
+// There must be no spurious newlines at the beginning or end of the certs
+// Root certificate if using TLS (AmazonRootCA1.pem)
+static const char MQTT_ROOT_CERT[] = R"ROOTCA(
 -----BEGIN CERTIFICATE-----
 ...                                               // FIXME
 -----END CERTIFICATE-----
 )ROOTCA";
 
-// Device Certificate (XXXXXXXXXX-certificate.pem.crt)
-static const char AWS_CERT_CRT[] = R"DEVICECERT(
+// This is for MQTT_AUTH=="x509"
+// There must be no spurious newlines at the beginning or end of the certs
+// Device Certificate if using x509 authenticiation (XXXXXXXXXX-certificate.pem.crt)
+static const char MQTT_DEVICE_CERT[] = R"DEVICECERT(
 -----BEGIN CERTIFICATE-----
 ...                                               // FIXME
 -----END CERTIFICATE-----
 )DEVICECERT";
 
-// Device Private Key (XXXXXXXXXX-private.pem.key)
-static const char AWS_CERT_PRIVATE[] = R"PRIVATEKEY(
+// This is for MQTT_AUTH=="x509"
+// There must be no spurious newlines at the beginning or end of the certs
+// Device Private Key if using x509 authenticiation (XXXXXXXXXX-private.pem.key)
+static const char MQTT_DEVICE_KEY[] = R"PRIVATEKEY(
 -----BEGIN RSA PRIVATE KEY-----
 ...                                               // FIXME
 -----END RSA PRIVATE KEY-----

--- a/firmware-arduino/src/mqtt.cpp
+++ b/firmware-arduino/src/mqtt.cpp
@@ -2,7 +2,7 @@
 //
 // Summarized from the design document:
 //
-// The mqtt topic strings and JSON data formats are defined by aws-iot-backend/MQTT-PROTOCOL.md.
+// The mqtt topic strings and JSON data formats are defined by MQTT-PROTOCOL.md.
 //
 // Summary:
 //
@@ -196,7 +196,7 @@ static void enqueue_data(const SnappySenseData& data) {
   String topic;
   String body;
 
-  // The topic string and JSON data format are defined by aws-iot-backend/MQTT-PROTOCOL.md
+  // The topic string and JSON data format are defined by MQTT-PROTOCOL.md
   topic += "snappy/observation/";
   topic += mqtt_device_class();
   topic += "/";
@@ -347,7 +347,7 @@ static void generate_startup_message() {
   String topic;
   String body;
 
-  // The topic string and JSON data format are defined by aws-iot-backend/MQTT-PROTOCOL.md
+  // The topic string and JSON data format are defined by MQTT-PROTOCOL.md
   topic += "snappy/startup/";
   topic += mqtt_device_class();
   topic += "/";

--- a/firmware-arduino/src/sensor.cpp
+++ b/firmware-arduino/src/sensor.cpp
@@ -265,7 +265,7 @@ SnappyMetaDatum snappy_metadata[] = {
    .format           = nullptr}
 };
 
-// The JSON data format is defined by aws-iot-backend/MQTT-PROTOCOL.md
+// The JSON data format is defined by MQTT-PROTOCOL.md
 String format_readings_as_json(const SnappySenseData& data) {
   String buf;
   buf += '{';

--- a/firmware-arduino/src/util.cpp
+++ b/firmware-arduino/src/util.cpp
@@ -71,7 +71,7 @@ String fmt(const char* format, ...) {
 }
 
 String format_timestamp(time_t time) {
-  // Timestamp format defined in aws-iot-backend/MQTT-PROTOCOL.md.
+  // Timestamp format defined in MQTT-PROTOCOL.md.
   char buf[256];
   snprintf(buf, sizeof(buf), "%llu", (unsigned long long) time);
   return String(buf);


### PR DESCRIPTION
Significant config changes to generalize what was introduced for AWS.  Device config files will need to be rewritten, old configs are not supported and will fail the version check.